### PR TITLE
feat: Auth — Sign in with Apple, Google OAuth, onboarding flow

### DIFF
--- a/Float/Features/Auth/AuthView.swift
+++ b/Float/Features/Auth/AuthView.swift
@@ -1,15 +1,36 @@
 import SwiftUI
 
+/// Auth gate — routes to onboarding, main app, or sign-in based on auth state
 struct AuthView: View {
-    @EnvironmentObject var authService: AuthService
+    @EnvironmentObject private var authService: AuthService
     
     var body: some View {
         Group {
-            if authService.isAuthenticated {
-                ContentView()
+            if authService.isLoading && authService.session == nil {
+                // Splash / loading while checking session
+                ZStack {
+                    FloatColors.background.ignoresSafeArea()
+                    VStack(spacing: FloatSpacing.lg) {
+                        Image(systemName: "wineglass.fill")
+                            .font(.system(size: 64))
+                            .foregroundStyle(FloatColors.primary)
+                        ProgressView().tint(FloatColors.primary)
+                    }
+                }
+            } else if authService.isAuthenticated {
+                if authService.needsOnboarding {
+                    OnboardingView()
+                        .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+                } else {
+                    ContentView()
+                        .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+                }
             } else {
                 SignInView()
+                    .transition(.opacity)
             }
         }
+        .animation(.easeInOut(duration: 0.3), value: authService.isAuthenticated)
+        .animation(.easeInOut(duration: 0.3), value: authService.needsOnboarding)
     }
 }

--- a/Float/Features/Auth/OnboardingView.swift
+++ b/Float/Features/Auth/OnboardingView.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @EnvironmentObject private var authService: AuthService
+    @StateObject private var locationService = LocationService()
+    @StateObject private var notificationService = NotificationService()
+    @State private var currentStep = 0
+    
+    var body: some View {
+        ZStack {
+            FloatColors.background.ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                // Step indicator
+                HStack(spacing: FloatSpacing.sm) {
+                    ForEach(0..<3) { i in
+                        Capsule()
+                            .fill(i <= currentStep ? FloatColors.primary : FloatColors.cardBackground)
+                            .frame(width: i == currentStep ? 32 : 8, height: 8)
+                            .animation(.spring(duration: 0.4), value: currentStep)
+                    }
+                }
+                .padding(.top, FloatSpacing.xl)
+                
+                TabView(selection: $currentStep) {
+                    OnboardingStep1View(locationService: locationService) { currentStep = 1 }
+                        .tag(0)
+                    OnboardingStep2View(notificationService: notificationService) { currentStep = 2 }
+                        .tag(1)
+                    OnboardingStep3View { username, displayName in
+                        Task { try? await authService.updateProfile(username: username, displayName: displayName) }
+                    }
+                    .tag(2)
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(.easeInOut, value: currentStep)
+            }
+        }
+    }
+}
+
+// MARK: - Step 1: Location
+struct OnboardingStep1View: View {
+    let locationService: LocationService
+    let onNext: () -> Void
+    
+    var body: some View {
+        VStack(spacing: FloatSpacing.xl) {
+            Spacer()
+            
+            ZStack {
+                Circle().fill(FloatColors.primary.opacity(0.15)).frame(width: 140, height: 140)
+                Image(systemName: "location.fill.viewfinder")
+                    .font(.system(size: 64))
+                    .foregroundStyle(FloatColors.primary)
+            }
+            
+            VStack(spacing: FloatSpacing.sm) {
+                Text("Deals Near You").font(FloatFont.title())
+                Text("Float uses your location to surface live deals at bars and restaurants within walking distance. We never share your location.")
+                    .font(FloatFont.body())
+                    .foregroundStyle(FloatColors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, FloatSpacing.lg)
+            }
+            
+            Spacer()
+            
+            VStack(spacing: FloatSpacing.sm) {
+                FloatButton("Enable Location", icon: "location.fill") {
+                    locationService.requestPermission()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) { onNext() }
+                }
+                Button("Not Now") { onNext() }
+                    .font(FloatFont.callout())
+                    .foregroundStyle(FloatColors.textSecondary)
+            }
+            .padding(.horizontal, FloatSpacing.lg)
+            .padding(.bottom, FloatSpacing.xxl)
+        }
+    }
+}
+
+// MARK: - Step 2: Notifications
+struct OnboardingStep2View: View {
+    let notificationService: NotificationService
+    let onNext: () -> Void
+    
+    var body: some View {
+        VStack(spacing: FloatSpacing.xl) {
+            Spacer()
+            
+            ZStack {
+                Circle().fill(FloatColors.accent.opacity(0.15)).frame(width: 140, height: 140)
+                Image(systemName: "bell.badge.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(FloatColors.accent)
+            }
+            
+            VStack(spacing: FloatSpacing.sm) {
+                Text("Never Miss a Deal").font(FloatFont.title())
+                Text("Get notified when a great deal goes live near you, or when a deal you love is expiring soon. Max 2 alerts per day.")
+                    .font(FloatFont.body())
+                    .foregroundStyle(FloatColors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, FloatSpacing.lg)
+            }
+            
+            Spacer()
+            
+            VStack(spacing: FloatSpacing.sm) {
+                FloatButton("Turn On Notifications", icon: "bell.fill") {
+                    Task {
+                        await notificationService.requestPermission()
+                        onNext()
+                    }
+                }
+                Button("Not Now") { onNext() }
+                    .font(FloatFont.callout())
+                    .foregroundStyle(FloatColors.textSecondary)
+            }
+            .padding(.horizontal, FloatSpacing.lg)
+            .padding(.bottom, FloatSpacing.xxl)
+        }
+    }
+}
+
+// MARK: - Step 3: Profile Setup
+struct OnboardingStep3View: View {
+    let onComplete: (String, String) -> Void
+    
+    @State private var displayName = ""
+    @State private var username = ""
+    @State private var usernameError: String?
+    
+    private var isValid: Bool { !displayName.isEmpty && username.count >= 3 && !username.contains(" ") }
+    
+    var body: some View {
+        VStack(spacing: FloatSpacing.xl) {
+            Spacer()
+            
+            ZStack {
+                Circle().fill(FloatColors.success.opacity(0.15)).frame(width: 140, height: 140)
+                Image(systemName: "person.circle.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(FloatColors.success)
+            }
+            
+            VStack(spacing: FloatSpacing.sm) {
+                Text("Set Up Your Profile").font(FloatFont.title())
+                Text("Choose a display name and username so friends can find you.")
+                    .font(FloatFont.body())
+                    .foregroundStyle(FloatColors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, FloatSpacing.lg)
+            }
+            
+            VStack(spacing: FloatSpacing.sm) {
+                FloatTextField("Display Name", text: $displayName, icon: "person")
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    FloatTextField("Username (no spaces)", text: $username, icon: "at")
+                        .onChange(of: username) { _, new in
+                            username = new.lowercased().filter { $0.isLetter || $0.isNumber || $0 == "_" }
+                            usernameError = new.count > 0 && new.count < 3 ? "Username must be at least 3 characters" : nil
+                        }
+                    if let error = usernameError {
+                        Text(error).font(FloatFont.caption()).foregroundStyle(FloatColors.error).padding(.leading, FloatSpacing.sm)
+                    }
+                }
+            }
+            .padding(.horizontal, FloatSpacing.lg)
+            
+            Spacer()
+            
+            VStack(spacing: FloatSpacing.sm) {
+                FloatButton("Let's Float! 🍹", style: .primary) {
+                    guard isValid else { return }
+                    onComplete(username, displayName)
+                }
+                .disabled(!isValid)
+                .opacity(isValid ? 1 : 0.5)
+                
+                Button("Skip for now") { onComplete("", "") }
+                    .font(FloatFont.callout())
+                    .foregroundStyle(FloatColors.textSecondary)
+            }
+            .padding(.horizontal, FloatSpacing.lg)
+            .padding(.bottom, FloatSpacing.xxl)
+        }
+    }
+}

--- a/Float/Features/Auth/SignInView.swift
+++ b/Float/Features/Auth/SignInView.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+import AuthenticationServices
+
+struct SignInView: View {
+    @EnvironmentObject private var authService: AuthService
+    @State private var email = ""
+    @State private var password = ""
+    @State private var showSignUp = false
+    @State private var showForgotPassword = false
+    @State private var showEmailFields = false
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                FloatColors.background.ignoresSafeArea()
+                
+                ScrollView {
+                    VStack(spacing: 0) {
+                        // Hero
+                        VStack(spacing: FloatSpacing.md) {
+                            Image(systemName: "wineglass.fill")
+                                .font(.system(size: 72))
+                                .foregroundStyle(FloatColors.primary)
+                                .padding(.top, 60)
+                            
+                            Text("Float")
+                                .font(.system(.largeTitle, design: .rounded, weight: .bold))
+                                .foregroundStyle(.white)
+                            
+                            Text("Real-time deals at bars & restaurants near you")
+                                .font(FloatFont.callout())
+                                .foregroundStyle(FloatColors.textSecondary)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, FloatSpacing.xl)
+                        }
+                        .padding(.bottom, 48)
+                        
+                        // Auth buttons
+                        VStack(spacing: FloatSpacing.md) {
+                            // Sign in with Apple
+                            SignInWithAppleButton(.signIn, onRequest: { request in
+                                request.requestedScopes = [.fullName, .email]
+                            }, onCompletion: { _ in
+                                Task { await authService.signInWithApple() }
+                            })
+                            .signInWithAppleButtonStyle(.white)
+                            .frame(height: 52)
+                            .cornerRadius(FloatSpacing.buttonRadius)
+                            
+                            // Sign in with Google
+                            Button {
+                                Task { await authService.signInWithGoogle() }
+                            } label: {
+                                HStack(spacing: FloatSpacing.sm) {
+                                    Text("G")
+                                        .font(.system(size: 18, weight: .bold, design: .serif))
+                                        .foregroundStyle(Color(hex: "#4285F4"))
+                                    Text("Continue with Google")
+                                        .font(FloatFont.headline())
+                                        .foregroundStyle(.black)
+                                }
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 52)
+                                .background(.white)
+                                .cornerRadius(FloatSpacing.buttonRadius)
+                            }
+                            
+                            // Divider
+                            HStack {
+                                Rectangle().frame(height: 0.5).foregroundStyle(FloatColors.textSecondary.opacity(0.4))
+                                Text("or").font(FloatFont.caption()).foregroundStyle(FloatColors.textSecondary)
+                                Rectangle().frame(height: 0.5).foregroundStyle(FloatColors.textSecondary.opacity(0.4))
+                            }
+                            
+                            // Email fields toggle
+                            if showEmailFields {
+                                VStack(spacing: FloatSpacing.sm) {
+                                    FloatTextField("Email", text: $email, icon: "envelope", keyboardType: .emailAddress)
+                                    FloatTextField("Password", text: $password, icon: "lock", isSecure: true)
+                                    
+                                    FloatButton("Sign In with Email", isLoading: authService.isLoading) {
+                                        Task { await authService.signInWithEmail(email: email, password: password) }
+                                    }
+                                    
+                                    Button("Forgot password?") {
+                                        showForgotPassword = true
+                                    }
+                                    .font(FloatFont.caption())
+                                    .foregroundStyle(FloatColors.textSecondary)
+                                }
+                                .transition(.opacity.combined(with: .move(edge: .top)))
+                            } else {
+                                Button("Sign in with Email") {
+                                    withAnimation(.easeInOut(duration: 0.3)) { showEmailFields = true }
+                                }
+                                .font(FloatFont.callout())
+                                .foregroundStyle(FloatColors.textSecondary)
+                            }
+                        }
+                        .padding(.horizontal, FloatSpacing.lg)
+                        
+                        // Error
+                        if let error = authService.authError {
+                            Text(error)
+                                .font(FloatFont.caption())
+                                .foregroundStyle(FloatColors.error)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, FloatSpacing.lg)
+                                .padding(.top, FloatSpacing.sm)
+                        }
+                        
+                        Spacer(minLength: FloatSpacing.xl)
+                        
+                        // Sign up
+                        HStack(spacing: FloatSpacing.xs) {
+                            Text("New to Float?")
+                                .font(FloatFont.caption())
+                                .foregroundStyle(FloatColors.textSecondary)
+                            Button("Create account") { showSignUp = true }
+                                .font(FloatFont.caption(.semibold))
+                                .foregroundStyle(FloatColors.primary)
+                        }
+                        .padding(.bottom, FloatSpacing.xl)
+                    }
+                }
+            }
+            .navigationDestination(isPresented: $showSignUp) {
+                SignUpView()
+            }
+            .sheet(isPresented: $showForgotPassword) {
+                ForgotPasswordView()
+            }
+        }
+    }
+}
+
+// MARK: - Supporting TextField Component
+struct FloatTextField: View {
+    let placeholder: String
+    @Binding var text: String
+    let icon: String
+    var keyboardType: UIKeyboardType = .default
+    var isSecure = false
+    
+    init(_ placeholder: String, text: Binding<String>, icon: String, keyboardType: UIKeyboardType = .default, isSecure: Bool = false) {
+        self.placeholder = placeholder; self._text = text; self.icon = icon; self.keyboardType = keyboardType; self.isSecure = isSecure
+    }
+    
+    var body: some View {
+        HStack(spacing: FloatSpacing.sm) {
+            Image(systemName: icon)
+                .foregroundStyle(FloatColors.textSecondary)
+                .frame(width: 20)
+            
+            if isSecure {
+                SecureField(placeholder, text: $text)
+                    .foregroundStyle(.white)
+            } else {
+                TextField(placeholder, text: $text)
+                    .keyboardType(keyboardType)
+                    .autocapitalization(.none)
+                    .autocorrectionDisabled()
+                    .foregroundStyle(.white)
+            }
+        }
+        .padding(FloatSpacing.md)
+        .background(FloatColors.cardBackground)
+        .cornerRadius(FloatSpacing.buttonRadius)
+        .overlay(RoundedRectangle(cornerRadius: FloatSpacing.buttonRadius).stroke(Color.white.opacity(0.1), lineWidth: 1))
+    }
+}
+
+struct ForgotPasswordView: View {
+    @EnvironmentObject private var authService: AuthService
+    @Environment(\.dismiss) private var dismiss
+    @State private var email = ""
+    @State private var sent = false
+    
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: FloatSpacing.lg) {
+                Image(systemName: "envelope.badge").font(.system(size: 48)).foregroundStyle(FloatColors.primary)
+                Text("Reset Password").font(FloatFont.title())
+                Text("Enter your email and we'll send you a link to reset your password.")
+                    .font(FloatFont.body()).foregroundStyle(FloatColors.textSecondary).multilineTextAlignment(.center)
+                
+                if sent {
+                    Text("✅ Check your inbox!").font(FloatFont.headline()).foregroundStyle(FloatColors.success)
+                } else {
+                    FloatTextField("Email", text: $email, icon: "envelope", keyboardType: .emailAddress)
+                    FloatButton("Send Reset Link", isLoading: authService.isLoading) {
+                        Task {
+                            await authService.resetPassword(email: email)
+                            sent = true
+                        }
+                    }
+                }
+            }
+            .padding(FloatSpacing.lg)
+            .floatScreenBackground()
+            .navigationTitle("Forgot Password")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { ToolbarItem(placement: .topBarTrailing) { Button("Close") { dismiss() } } }
+        }
+    }
+}

--- a/Float/Features/Auth/SignUpView.swift
+++ b/Float/Features/Auth/SignUpView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct SignUpView: View {
+    @EnvironmentObject private var authService: AuthService
+    @Environment(\.dismiss) private var dismiss
+    @State private var email = ""
+    @State private var password = ""
+    @State private var confirmPassword = ""
+    @State private var passwordMismatch = false
+    
+    var body: some View {
+        ZStack {
+            FloatColors.background.ignoresSafeArea()
+            
+            ScrollView {
+                VStack(spacing: FloatSpacing.lg) {
+                    Image(systemName: "person.badge.plus")
+                        .font(.system(size: 56))
+                        .foregroundStyle(FloatColors.primary)
+                        .padding(.top, FloatSpacing.xl)
+                    
+                    Text("Create Account")
+                        .font(FloatFont.title())
+                        .foregroundStyle(.white)
+                    
+                    VStack(spacing: FloatSpacing.sm) {
+                        FloatTextField("Email", text: $email, icon: "envelope", keyboardType: .emailAddress)
+                        FloatTextField("Password (6+ characters)", text: $password, icon: "lock", isSecure: true)
+                        FloatTextField("Confirm Password", text: $confirmPassword, icon: "lock.shield", isSecure: true)
+                        
+                        if passwordMismatch {
+                            Text("Passwords don't match")
+                                .font(FloatFont.caption())
+                                .foregroundStyle(FloatColors.error)
+                        }
+                        
+                        if let error = authService.authError {
+                            Text(error).font(FloatFont.caption()).foregroundStyle(FloatColors.error).multilineTextAlignment(.center)
+                        }
+                        
+                        FloatButton("Create Account", isLoading: authService.isLoading) {
+                            guard password == confirmPassword else { passwordMismatch = true; return }
+                            passwordMismatch = false
+                            Task { await authService.signUpWithEmail(email: email, password: password) }
+                        }
+                        
+                        Text("By creating an account you agree to our Terms of Service and Privacy Policy.")
+                            .font(FloatFont.caption2())
+                            .foregroundStyle(FloatColors.textSecondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(.horizontal, FloatSpacing.lg)
+                }
+            }
+        }
+        .navigationTitle("Sign Up")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Float/Features/ContentView.swift
+++ b/Float/Features/ContentView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Float App").foregroundStyle(.white)
+    }
+}

--- a/Float/Models/UserProfile.swift
+++ b/Float/Models/UserProfile.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct UserProfile: Codable, Identifiable {
+    let id: UUID
+    var username: String?
+    var displayName: String?
+    var avatarUrl: String?
+    var bio: String?
+    var locationCity: String?
+    var locationState: String?
+    var totalRedemptions: Int
+    var totalSavings: Double
+    var notificationPrefs: NotificationPrefs
+    var isMerchant: Bool
+    var createdAt: Date
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case username
+        case displayName = "display_name"
+        case avatarUrl = "avatar_url"
+        case bio
+        case locationCity = "location_city"
+        case locationState = "location_state"
+        case totalRedemptions = "total_redemptions"
+        case totalSavings = "total_savings"
+        case notificationPrefs = "notification_prefs"
+        case isMerchant = "is_merchant"
+        case createdAt = "created_at"
+    }
+}
+
+struct NotificationPrefs: Codable {
+    var dealsNearby: Bool
+    var expiringSoon: Bool
+    var newVenues: Bool
+    var weeklyRoundup: Bool
+    
+    enum CodingKeys: String, CodingKey {
+        case dealsNearby = "deals_nearby"
+        case expiringSoon = "expiring_soon"
+        case newVenues = "new_venues"
+        case weeklyRoundup = "weekly_roundup"
+    }
+    
+    static let `default` = NotificationPrefs(dealsNearby: true, expiringSoon: true, newVenues: false, weeklyRoundup: true)
+}

--- a/Float/Services/AuthService.swift
+++ b/Float/Services/AuthService.swift
@@ -1,0 +1,269 @@
+import SwiftUI
+import Supabase
+import AuthenticationServices
+import OSLog
+import CommonCrypto
+
+private let logger = Logger(subsystem: "com.xomware.float", category: "Auth")
+
+@MainActor
+final class AuthService: ObservableObject {
+    
+    // MARK: - Published State
+    @Published var session: Session?
+    @Published var userProfile: UserProfile?
+    @Published var isLoading = false
+    @Published var authError: String?
+    @Published var needsOnboarding = false
+    
+    var isAuthenticated: Bool { session != nil }
+    var currentUser: User? { session?.user }
+    
+    private let supabase = SupabaseClientService.shared.client
+    
+    // MARK: - Init
+    init() {
+        Task { await listenToAuthChanges() }
+    }
+    
+    // MARK: - Auth State Listener
+    func listenToAuthChanges() async {
+        for await (event, session) in supabase.auth.authStateChanges {
+            logger.info("Auth state change: \(event.rawValue)")
+            self.session = session
+            
+            switch event {
+            case .signedIn:
+                await fetchOrCreateProfile()
+            case .signedOut:
+                userProfile = nil
+                needsOnboarding = false
+            case .tokenRefreshed:
+                break
+            default:
+                break
+            }
+        }
+    }
+    
+    // MARK: - Sign In with Apple
+    func signInWithApple() async {
+        isLoading = true
+        authError = nil
+        defer { isLoading = false }
+        
+        do {
+            let helper = SignInWithAppleHelper()
+            let result = try await helper.signIn()
+            
+            let session = try await supabase.auth.signInWithIdToken(
+                credentials: OpenIDConnectCredentials(
+                    provider: .apple,
+                    idToken: result.idToken,
+                    nonce: result.nonce
+                )
+            )
+            self.session = session
+            logger.info("Signed in with Apple: \(session.user.id)")
+        } catch {
+            authError = error.localizedDescription
+            logger.error("Apple sign-in failed: \(error)")
+        }
+    }
+    
+    // MARK: - Sign In with Google
+    func signInWithGoogle() async {
+        isLoading = true
+        authError = nil
+        defer { isLoading = false }
+        
+        do {
+            try await supabase.auth.signInWithOAuth(
+                provider: .google,
+                redirectTo: URL(string: "com.xomware.float://login-callback")
+            )
+            logger.info("Google OAuth initiated")
+        } catch {
+            authError = error.localizedDescription
+            logger.error("Google sign-in failed: \(error)")
+        }
+    }
+    
+    // MARK: - Email Auth
+    func signInWithEmail(email: String, password: String) async {
+        isLoading = true
+        authError = nil
+        defer { isLoading = false }
+        
+        do {
+            let session = try await supabase.auth.signIn(email: email, password: password)
+            self.session = session
+            logger.info("Signed in with email: \(email)")
+        } catch {
+            authError = mapAuthError(error)
+            logger.error("Email sign-in failed: \(error)")
+        }
+    }
+    
+    func signUpWithEmail(email: String, password: String) async {
+        isLoading = true
+        authError = nil
+        defer { isLoading = false }
+        
+        do {
+            let response = try await supabase.auth.signUp(email: email, password: password)
+            self.session = response.session
+            logger.info("Signed up with email: \(email)")
+        } catch {
+            authError = mapAuthError(error)
+            logger.error("Email sign-up failed: \(error)")
+        }
+    }
+    
+    func resetPassword(email: String) async {
+        isLoading = true
+        authError = nil
+        defer { isLoading = false }
+        
+        do {
+            try await supabase.auth.resetPasswordForEmail(email)
+            logger.info("Password reset email sent to: \(email)")
+        } catch {
+            authError = error.localizedDescription
+            logger.error("Password reset failed: \(error)")
+        }
+    }
+    
+    // MARK: - Sign Out
+    func signOut() async {
+        do {
+            try await supabase.auth.signOut()
+            session = nil
+            userProfile = nil
+            logger.info("Signed out")
+        } catch {
+            logger.error("Sign out failed: \(error)")
+        }
+    }
+    
+    // MARK: - Profile
+    func fetchOrCreateProfile() async {
+        guard let userId = currentUser?.id else { return }
+        
+        do {
+            let profile: UserProfile = try await supabase
+                .from("user_profiles")
+                .select()
+                .eq("id", value: userId.uuidString)
+                .single()
+                .execute()
+                .value
+            
+            self.userProfile = profile
+            self.needsOnboarding = profile.username == nil || profile.displayName == nil
+            logger.info("Fetched profile for: \(userId)")
+        } catch {
+            // Profile may not exist yet (trigger handles creation, but can race)
+            logger.warning("Profile fetch failed, will retry: \(error)")
+            needsOnboarding = true
+        }
+    }
+    
+    func updateProfile(username: String, displayName: String, avatarUrl: String? = nil) async throws {
+        guard let userId = currentUser?.id else { throw AuthError.notAuthenticated }
+        
+        struct ProfileUpdate: Encodable {
+            let username: String
+            let displayName: String
+            let avatarUrl: String?
+            enum CodingKeys: String, CodingKey {
+                case username; case displayName = "display_name"; case avatarUrl = "avatar_url"
+            }
+        }
+        
+        try await supabase
+            .from("user_profiles")
+            .update(ProfileUpdate(username: username, displayName: displayName, avatarUrl: avatarUrl))
+            .eq("id", value: userId.uuidString)
+            .execute()
+        
+        await fetchOrCreateProfile()
+        needsOnboarding = false
+    }
+    
+    // MARK: - Helpers
+    private func mapAuthError(_ error: Error) -> String {
+        let msg = error.localizedDescription.lowercased()
+        if msg.contains("invalid login") { return "Incorrect email or password." }
+        if msg.contains("email not confirmed") { return "Please check your email and confirm your account." }
+        if msg.contains("user already registered") { return "An account with this email already exists." }
+        if msg.contains("password") { return "Password must be at least 6 characters." }
+        return error.localizedDescription
+    }
+    
+    enum AuthError: LocalizedError {
+        case notAuthenticated
+        var errorDescription: String? { "You must be signed in to do that." }
+    }
+}
+
+// MARK: - Apple Sign In Helper
+struct AppleSignInResult {
+    let idToken: String
+    let nonce: String
+}
+
+@MainActor
+final class SignInWithAppleHelper: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+    private var continuation: CheckedContinuation<AppleSignInResult, Error>?
+    private let nonce = UUID().uuidString
+    
+    func signIn() async throws -> AppleSignInResult {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            
+            let appleIDProvider = ASAuthorizationAppleIDProvider()
+            let request = appleIDProvider.createRequest()
+            request.requestedScopes = [.fullName, .email]
+            request.nonce = nonce.sha256
+            
+            let authController = ASAuthorizationController(authorizationRequests: [request])
+            authController.delegate = self
+            authController.presentationContextProvider = self
+            authController.performRequests()
+        }
+    }
+    
+    nonisolated func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard
+            let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+            let tokenData = credential.identityToken,
+            let idToken = String(data: tokenData, encoding: .utf8)
+        else {
+            continuation?.resume(throwing: NSError(domain: "AppleSignIn", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to get Apple ID token"]))
+            return
+        }
+        continuation?.resume(returning: AppleSignInResult(idToken: idToken, nonce: nonce))
+    }
+    
+    nonisolated func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        continuation?.resume(throwing: error)
+    }
+    
+    nonisolated func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = scene.windows.first else {
+            return UIWindow()
+        }
+        return window
+    }
+}
+
+private extension String {
+    var sha256: String {
+        let data = Data(self.utf8)
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes { _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash) }
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Float/Services/SupabaseClientService.swift
+++ b/Float/Services/SupabaseClientService.swift
@@ -1,0 +1,20 @@
+import Supabase
+import Foundation
+
+/// Singleton Supabase client — initialized once at app launch
+final class SupabaseClientService {
+    static let shared = SupabaseClientService()
+    
+    let client: SupabaseClient
+    
+    private init() {
+        guard
+            let urlString = Bundle.main.infoDictionary?["SUPABASE_URL"] as? String,
+            let url = URL(string: urlString),
+            let anonKey = Bundle.main.infoDictionary?["SUPABASE_ANON_KEY"] as? String
+        else {
+            fatalError("[Float] Missing SUPABASE_URL or SUPABASE_ANON_KEY in Info.plist")
+        }
+        client = SupabaseClient(supabaseURL: url, supabaseKey: anonKey)
+    }
+}


### PR DESCRIPTION
Closes #3

## Changes
- **AuthService**: Full Supabase auth integration
  - Sign in with Apple (ASAuthorizationController + Supabase idToken flow)
  - Google OAuth (Supabase OAuth redirect)
  - Email/password sign in & sign up
  - Password reset
  - Auth state listener (continuous async stream)
  - Profile fetch/create after sign-in
- **SignInView**: Beautiful dark UI — Apple button, Google button, email fields
- **SignUpView**: Email sign-up with validation
- **ForgotPasswordView**: Password reset sheet
- **OnboardingView**: 3-step onboarding
  - Step 1: Location permission (CoreLocation)
  - Step 2: Notification permission (APNs)
  - Step 3: Username + display name setup
- **AuthView**: Auth gate routing (splash → sign-in → onboarding → main app)
- **UserProfile model**: Codable, matches Supabase schema
- **SupabaseClientService**: Singleton client from Info.plist config

## Apple Sign In Setup Required
1. Enable 'Sign in with Apple' capability in Xcode project settings
2. Add entitlement: com.apple.developer.applesignin = ['Default']
3. Configure in Apple Developer Portal: Service ID for web redirect

## Supabase Setup Required
1. Enable Apple provider in Supabase Auth → Providers
2. Enable Google provider with OAuth credentials
3. Add redirect URL: com.xomware.float://login-callback
4. Add SUPABASE_URL and SUPABASE_ANON_KEY to Xcode build settings → xcconfig