### PR TITLE
chore: Add Dependabot + PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+<!-- What does this PR do? -->
+
+## Changes
+- 
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code cleanup
+- [ ] Documentation
+- [ ] Dependencies / chore
+
+## Testing
+- [ ] Unit tests pass (`swift test`)
+- [ ] Tested on simulator (iPhone 15 Pro / iOS 17)
+- [ ] No new SwiftLint warnings
+
+## Screenshots (if UI changes)
+<!-- Attach before/after screenshots -->
+
+## Linked Issues
+Closes #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Adds Dependabot config for weekly Swift and GitHub Actions dependency updates. Adds standardized PR template.

Closes #49