### PR TITLE
feat: Venue Photo Gallery — swipeable venue photos (#72)

### DIFF
--- a/Float/Features/Deals/DealCardView.swift
+++ b/Float/Features/Deals/DealCardView.swift
@@ -2,10 +2,47 @@ import SwiftUI
 
 struct DealCardView: View {
     let deal: Deal
+    var heroImageURL: String? = nil
     @State private var isBookmarked = false
 
     var body: some View {
         FloatCard {
+            VStack(alignment: .leading, spacing: 0) {
+                // Hero image thumbnail
+                if let imageURL = heroImageURL, let url = URL(string: imageURL) {
+                    ZStack(alignment: .bottomLeading) {
+                        AsyncImage(url: url) { phase in
+                            switch phase {
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(height: 120)
+                                    .clipped()
+                            case .empty:
+                                Rectangle()
+                                    .fill(FloatColors.cardBackground)
+                                    .frame(height: 120)
+                                    .overlay { ProgressView().tint(FloatColors.primary) }
+                            default:
+                                Rectangle()
+                                    .fill(FloatColors.cardBackground)
+                                    .frame(height: 120)
+                            }
+                        }
+
+                        // Gradient overlay for text readability
+                        LinearGradient(
+                            colors: [.clear, .black.opacity(0.5)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 60)
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: FloatSpacing.cardRadius - 2))
+                    .padding(.bottom, FloatSpacing.sm)
+                }
+
             VStack(alignment: .leading, spacing: FloatSpacing.sm) {
                 // Header with venue and distance
                 HStack(alignment: .top, spacing: FloatSpacing.sm) {
@@ -101,6 +138,7 @@ struct DealCardView: View {
                     .accessibilityLabel(isBookmarked ? "Remove bookmark" : "Bookmark this deal")
                     .accessibilityAddTraits(isBookmarked ? [.isButton, .isSelected] : .isButton)
                 }
+            }
             }
         }
         .cardPressEffect()

--- a/Float/Features/Venue/VenuePhotoGalleryView.swift
+++ b/Float/Features/Venue/VenuePhotoGalleryView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct VenuePhotoGalleryView: View {
+    let photos: [VenuePhoto]
+    @State private var currentIndex = 0
+    @State private var magnifyScale: CGFloat = 1.0
+    @State private var lastMagnifyScale: CGFloat = 1.0
+
+    var body: some View {
+        if photos.isEmpty {
+            placeholderView
+        } else {
+            galleryView
+        }
+    }
+
+    // MARK: - Gallery
+
+    private var galleryView: some View {
+        ZStack(alignment: .topTrailing) {
+            TabView(selection: $currentIndex) {
+                ForEach(Array(photos.enumerated()), id: \.element.id) { index, photo in
+                    photoPage(photo)
+                        .tag(index)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .automatic))
+            .frame(height: 260)
+
+            // Photo count badge
+            photoBadge
+        }
+    }
+
+    private func photoPage(_ photo: VenuePhoto) -> some View {
+        AsyncImage(url: URL(string: photo.url)) { phase in
+            switch phase {
+            case .empty:
+                skeletonPlaceholder
+            case .success(let image):
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(height: 260)
+                    .clipped()
+                    .scaleEffect(magnifyScale)
+                    .gesture(
+                        MagnificationGesture()
+                            .onChanged { value in
+                                magnifyScale = lastMagnifyScale * value
+                            }
+                            .onEnded { _ in
+                                withAnimation(.spring(response: 0.3)) {
+                                    magnifyScale = max(1.0, min(magnifyScale, 3.0))
+                                    lastMagnifyScale = magnifyScale
+                                }
+                            }
+                    )
+                    .onTapGesture(count: 2) {
+                        withAnimation(.spring(response: 0.3)) {
+                            magnifyScale = magnifyScale > 1.0 ? 1.0 : 2.0
+                            lastMagnifyScale = magnifyScale
+                        }
+                    }
+            case .failure:
+                errorPlaceholder
+            @unknown default:
+                skeletonPlaceholder
+            }
+        }
+    }
+
+    private var photoBadge: some View {
+        Text("\(currentIndex + 1) / \(photos.count)")
+            .font(FloatFont.caption2(.semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, FloatSpacing.sm)
+            .padding(.vertical, FloatSpacing.xs)
+            .background(.black.opacity(0.6))
+            .clipShape(Capsule())
+            .padding(FloatSpacing.md)
+    }
+
+    // MARK: - Placeholders
+
+    private var placeholderView: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: FloatSpacing.cardRadius)
+                .fill(FloatColors.cardBackground)
+                .frame(height: 200)
+
+            Image(systemName: "building.2.fill")
+                .font(.system(size: 80))
+                .foregroundStyle(FloatColors.primary.opacity(0.3))
+        }
+    }
+
+    private var skeletonPlaceholder: some View {
+        Rectangle()
+            .fill(FloatColors.cardBackground)
+            .frame(height: 260)
+            .overlay {
+                ProgressView()
+                    .tint(FloatColors.primary)
+            }
+    }
+
+    private var errorPlaceholder: some View {
+        Rectangle()
+            .fill(FloatColors.cardBackground)
+            .frame(height: 260)
+            .overlay {
+                Image(systemName: "photo.fill")
+                    .font(.system(size: 40))
+                    .foregroundStyle(FloatColors.textSecondary.opacity(0.5))
+            }
+    }
+}

--- a/Float/Features/Venue/VenueProfileView.swift
+++ b/Float/Features/Venue/VenueProfileView.swift
@@ -7,6 +7,7 @@ struct VenueProfileView: View {
     @State private var venue: Venue?
     @State private var venueDeals: [Deal] = []
     @State private var isLoading = false
+    @State private var venuePhotos: [VenuePhoto] = []
     @Environment(\.dismiss) var dismiss
     
     var body: some View {
@@ -14,16 +15,10 @@ struct VenueProfileView: View {
             FloatColors.background.ignoresSafeArea()
             
             VStack(spacing: 0) {
-                // Header image area
+                // Photo gallery hero section
                 ZStack(alignment: .topLeading) {
-                    RoundedRectangle(cornerRadius: FloatSpacing.cardRadius)
-                        .fill(FloatColors.cardBackground)
-                        .frame(height: 200)
-                    
-                    Image(systemName: "building.2.fill")
-                        .font(.system(size: 80))
-                        .foregroundStyle(FloatColors.primary.opacity(0.3))
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    VenuePhotoGalleryView(photos: venuePhotos)
+                        .clipShape(RoundedRectangle(cornerRadius: FloatSpacing.cardRadius))
                     
                     Button(action: { dismiss() }) {
                         Image(systemName: "xmark.circle.fill")
@@ -179,6 +174,7 @@ struct VenueProfileView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task {
             await loadVenueData()
+            await loadVenuePhotos()
         }
     }
     
@@ -229,5 +225,13 @@ struct VenueProfileView: View {
                 distanceFromUser: 500
             )
         ]
+    }
+
+    private func loadVenuePhotos() async {
+        do {
+            venuePhotos = try await PhotoService.shared.fetchVenuePhotos(venueId: venueId)
+        } catch {
+            venuePhotos = []
+        }
     }
 }

--- a/Float/Models/VenuePhoto.swift
+++ b/Float/Models/VenuePhoto.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct VenuePhoto: Identifiable, Codable {
+    let id: UUID
+    let venueId: UUID
+    let url: String
+    let caption: String?
+    let sortOrder: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case venueId = "venue_id"
+        case url
+        case caption
+        case sortOrder = "sort_order"
+    }
+}

--- a/Float/Services/PhotoService.swift
+++ b/Float/Services/PhotoService.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Service for fetching venue photos from Supabase or mock data.
+actor PhotoService {
+    static let shared = PhotoService()
+
+    private init() {}
+
+    /// Fetch photos for a venue, sorted by `sort_order`.
+    /// Falls back to mock Unsplash URLs if Supabase is unavailable.
+    func fetchVenuePhotos(venueId: UUID) async throws -> [VenuePhoto] {
+        // Attempt Supabase fetch
+        if !SupabaseConfig.url.isEmpty, !SupabaseConfig.anonKey.isEmpty {
+            do {
+                return try await fetchFromSupabase(venueId: venueId)
+            } catch {
+                // Fall through to mock data
+            }
+        }
+        return mockPhotos(for: venueId)
+    }
+
+    private func fetchFromSupabase(venueId: UUID) async throws -> [VenuePhoto] {
+        guard let baseURL = URL(string: SupabaseConfig.url) else {
+            throw PhotoServiceError.invalidConfiguration
+        }
+
+        var components = URLComponents(url: baseURL.appendingPathComponent("/rest/v1/venue_photos"), resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            URLQueryItem(name: "venue_id", value: "eq.\(venueId.uuidString)"),
+            URLQueryItem(name: "order", value: "sort_order.asc"),
+            URLQueryItem(name: "select", value: "*")
+        ]
+
+        guard let url = components.url else {
+            throw PhotoServiceError.invalidConfiguration
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(SupabaseConfig.anonKey, forHTTPHeaderField: "apikey")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw PhotoServiceError.fetchFailed
+        }
+
+        let decoder = JSONDecoder()
+        return try decoder.decode([VenuePhoto].self, from: data)
+    }
+
+    // MARK: - Mock Data
+
+    private func mockPhotos(for venueId: UUID) -> [VenuePhoto] {
+        let unsplashPhotos: [(url: String, caption: String)] = [
+            ("https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?w=800", "Main dining area"),
+            ("https://images.unsplash.com/photo-1514933651103-005eec06c04b?w=800", "Bar seating"),
+            ("https://images.unsplash.com/photo-1555396273-367ea4eb4db5?w=800", "Outdoor patio"),
+            ("https://images.unsplash.com/photo-1466978913421-dad2ebd01d17?w=800", "Cozy interior"),
+            ("https://images.unsplash.com/photo-1552566626-52f8b828add9?w=800", "Evening ambiance")
+        ]
+
+        return unsplashPhotos.enumerated().map { index, photo in
+            VenuePhoto(
+                id: UUID(),
+                venueId: venueId,
+                url: photo.url,
+                caption: photo.caption,
+                sortOrder: index
+            )
+        }
+    }
+}
+
+enum PhotoServiceError: Error, LocalizedError {
+    case invalidConfiguration
+    case fetchFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration: return "Supabase configuration is invalid"
+        case .fetchFailed: return "Failed to fetch venue photos"
+        }
+    }
+}

--- a/FloatTests/PhotoServiceTests.swift
+++ b/FloatTests/PhotoServiceTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import Float
+
+final class PhotoServiceTests: XCTestCase {
+
+    func testMockPhotosReturnsFivePhotos() async throws {
+        let service = PhotoService.shared
+        let photos = try await service.fetchVenuePhotos(venueId: UUID())
+        XCTAssertEqual(photos.count, 5, "Mock should return 5 photos")
+    }
+
+    func testMockPhotosSortOrder() async throws {
+        let service = PhotoService.shared
+        let photos = try await service.fetchVenuePhotos(venueId: UUID())
+
+        for (index, photo) in photos.enumerated() {
+            XCTAssertEqual(photo.sortOrder, index, "Photo at index \(index) should have sortOrder \(index)")
+        }
+    }
+
+    func testMockPhotosHaveValidURLs() async throws {
+        let service = PhotoService.shared
+        let photos = try await service.fetchVenuePhotos(venueId: UUID())
+
+        for photo in photos {
+            XCTAssertNotNil(URL(string: photo.url), "Photo URL should be valid: \(photo.url)")
+            XCTAssertTrue(photo.url.contains("unsplash"), "Mock URLs should be from Unsplash")
+        }
+    }
+
+    func testMockPhotosHaveCaptions() async throws {
+        let service = PhotoService.shared
+        let photos = try await service.fetchVenuePhotos(venueId: UUID())
+
+        for photo in photos {
+            XCTAssertNotNil(photo.caption, "Mock photos should have captions")
+            XCTAssertFalse(photo.caption!.isEmpty, "Captions should not be empty")
+        }
+    }
+
+    func testMockPhotosMatchVenueId() async throws {
+        let venueId = UUID()
+        let service = PhotoService.shared
+        let photos = try await service.fetchVenuePhotos(venueId: venueId)
+
+        for photo in photos {
+            XCTAssertEqual(photo.venueId, venueId, "Photo venueId should match requested venueId")
+        }
+    }
+
+    func testVenuePhotoCodable() throws {
+        let photo = VenuePhoto(
+            id: UUID(),
+            venueId: UUID(),
+            url: "https://example.com/photo.jpg",
+            caption: "Test caption",
+            sortOrder: 0
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(photo)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(VenuePhoto.self, from: data)
+
+        XCTAssertEqual(decoded.id, photo.id)
+        XCTAssertEqual(decoded.venueId, photo.venueId)
+        XCTAssertEqual(decoded.url, photo.url)
+        XCTAssertEqual(decoded.caption, photo.caption)
+        XCTAssertEqual(decoded.sortOrder, photo.sortOrder)
+    }
+
+    func testVenuePhotoDecodesFromSnakeCase() throws {
+        let json = """
+        {
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "venue_id": "550e8400-e29b-41d4-a716-446655440001",
+            "url": "https://example.com/photo.jpg",
+            "caption": "Test",
+            "sort_order": 2
+        }
+        """.data(using: .utf8)!
+
+        let photo = try JSONDecoder().decode(VenuePhoto.self, from: json)
+        XCTAssertEqual(photo.sortOrder, 2)
+        XCTAssertEqual(photo.venueId.uuidString, "550E8400-E29B-41D4-A716-446655440001")
+    }
+}

--- a/supabase/migrations/20260301000001_add_venue_photos.sql
+++ b/supabase/migrations/20260301000001_add_venue_photos.sql
@@ -1,0 +1,26 @@
+-- Venue photos for gallery display
+CREATE TABLE venue_photos (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    venue_id uuid REFERENCES venues(id) ON DELETE CASCADE,
+    url text NOT NULL,
+    caption text,
+    sort_order integer DEFAULT 0,
+    created_at timestamptz DEFAULT now()
+);
+
+-- Index for fast lookup by venue
+CREATE INDEX idx_venue_photos_venue_id ON venue_photos(venue_id);
+
+-- RLS
+ALTER TABLE venue_photos ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can read venue photos
+CREATE POLICY "venue_photos_read_all" ON venue_photos
+    FOR SELECT USING (true);
+
+-- Only authenticated users (merchants) can manage photos
+CREATE POLICY "venue_photos_insert_auth" ON venue_photos
+    FOR INSERT WITH CHECK (auth.role() = 'authenticated');
+
+CREATE POLICY "venue_photos_delete_auth" ON venue_photos
+    FOR DELETE USING (auth.role() = 'authenticated');


### PR DESCRIPTION
## Summary
Adds a venue photo gallery feature with swipeable photos on venue profiles and hero thumbnails on deal cards.

### Changes
- **VenuePhoto model** — Codable struct with snake_case CodingKeys for Supabase compatibility
- **PhotoService** — Actor-based service with Supabase fetch + mock Unsplash fallback
- **VenuePhotoGalleryView** — Swipeable TabView with page dots, AsyncImage, pinch-to-zoom, photo count badge
- **VenueProfileView** — Replaced static header with photo gallery hero
- **DealCardView** — Optional hero image thumbnail with gradient overlay
- **Supabase migration** — venue_photos table with RLS policies
- **Unit tests** — 7 tests covering mock data, sort order, Codable

Closes #72