### PR TITLE
fix: bump minimum macOS to 10.15 to match Supabase requirement (#81)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Float",
-    platforms: [.iOS(.v17)],
+    platforms: [.iOS(.v17), .macOS(.v10_15)],
     products: [
         .library(name: "Float", targets: ["Float"]),
     ],


### PR DESCRIPTION
Fixes build error: Float requires macOS 10.13 (default) but Supabase requires 10.15. Adding explicit `.macOS(.v10_15)` platform to unblock Dependabot PRs #51, #52, #53, #54.

Closes #81