### PR TITLE
Map Pin Clustering & Deal Discovery Map

### DIFF
--- a/Float/Features/Map/ClusteredDealsBottomSheet.swift
+++ b/Float/Features/Map/ClusteredDealsBottomSheet.swift
@@ -1,0 +1,145 @@
+// ClusteredDealsBottomSheet.swift
+// Float
+
+import SwiftUI
+import CoreLocation
+
+struct ClusteredDealsBottomSheet: View {
+    let deals: [DealPin]
+    let userLocation: CLLocationCoordinate2D?
+    let onDismiss: () -> Void
+    let onSelectDeal: (DealPin) -> Void
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+                .onTapGesture { onDismiss() }
+
+            VStack(spacing: 0) {
+                // Handle bar
+                RoundedRectangle(cornerRadius: 2.5)
+                    .fill(FloatColors.textSecondary.opacity(0.3))
+                    .frame(width: 40, height: 5)
+                    .padding(.top, FloatSpacing.sm)
+                    .padding(.bottom, FloatSpacing.xs)
+
+                // Header
+                HStack {
+                    Text("\(deals.count) Deals Nearby")
+                        .font(FloatFont.headline())
+                    Spacer()
+                    Button(action: onDismiss) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(FloatColors.textSecondary)
+                            .font(.title3)
+                    }
+                }
+                .padding(.horizontal, FloatSpacing.md)
+                .padding(.bottom, FloatSpacing.sm)
+
+                // Deal list
+                ScrollView {
+                    LazyVStack(spacing: FloatSpacing.sm) {
+                        ForEach(deals) { pin in
+                            ClusteredDealCard(pin: pin, userLocation: userLocation)
+                                .onTapGesture { onSelectDeal(pin) }
+                        }
+                    }
+                    .padding(.horizontal, FloatSpacing.md)
+                    .padding(.bottom, FloatSpacing.lg)
+                }
+                .frame(maxHeight: 320)
+            }
+            .background(FloatColors.cardBackground)
+            .cornerRadius(FloatSpacing.cardRadius, corners: [.topLeft, .topRight])
+        }
+        .ignoresSafeArea(edges: .bottom)
+    }
+}
+
+struct ClusteredDealCard: View {
+    let pin: DealPin
+    let userLocation: CLLocationCoordinate2D?
+
+    var body: some View {
+        FloatCard {
+            HStack(spacing: FloatSpacing.sm) {
+                // Category icon
+                ZStack {
+                    Circle()
+                        .fill(pin.categoryColor)
+                        .frame(width: 40, height: 40)
+                    Image(systemName: categoryIcon)
+                        .foregroundStyle(.white)
+                        .font(.system(size: 16))
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(pin.venueName)
+                        .font(FloatFont.body(.semibold))
+                        .lineLimit(1)
+                    Text(pin.deal.discountDisplay)
+                        .font(FloatFont.caption(.semibold))
+                        .foregroundStyle(FloatColors.accent)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(formattedDistance)
+                        .font(FloatFont.caption(.regular))
+                        .foregroundStyle(FloatColors.textSecondary)
+                    Text(pin.expiresAt.timeRemainingShort)
+                        .font(FloatFont.caption(.regular))
+                        .foregroundStyle(pin.expiresAt.isExpiringSoon ? FloatColors.warning : FloatColors.textSecondary)
+                }
+            }
+        }
+    }
+
+    private var categoryIcon: String {
+        switch pin.category.lowercased() {
+        case "drink": return "wineglass.fill"
+        case "food": return "fork.knife"
+        case "both": return "cart.fill"
+        case "flash": return "bolt.fill"
+        default: return "tag.fill"
+        }
+    }
+
+    var formattedDistance: String {
+        guard let userLoc = userLocation else { return "" }
+        let pinLoc = CLLocation(latitude: pin.coordinate.latitude, longitude: pin.coordinate.longitude)
+        let userCLLoc = CLLocation(latitude: userLoc.latitude, longitude: userLoc.longitude)
+        let meters = pinLoc.distance(from: userCLLoc)
+        return Self.formatDistance(meters: meters)
+    }
+
+    /// Format a distance in meters to a human-readable string.
+    static func formatDistance(meters: Double) -> String {
+        if meters < 1000 {
+            return "\(Int(meters))m"
+        } else {
+            let miles = meters / 1609.34
+            return String(format: "%.1fmi", miles)
+        }
+    }
+}
+
+// MARK: - Corner Radius Helper
+extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape(RoundedCorner(radius: radius, corners: corners))
+    }
+}
+
+private struct RoundedCorner: Shape {
+    var radius: CGFloat
+    var corners: UIRectCorner
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}

--- a/Float/Features/Map/DealMapAnnotationView.swift
+++ b/Float/Features/Map/DealMapAnnotationView.swift
@@ -1,0 +1,110 @@
+// DealMapAnnotationView.swift
+// Float
+
+import MapKit
+import UIKit
+
+/// Individual deal pin annotation view with category icon and pulse animation.
+final class DealMapAnnotationView: MKAnnotationView {
+    static let reuseID = "DealPin"
+    static let clusterID = "DealCluster"
+
+    private let iconImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.tintColor = .white
+        iv.contentMode = .scaleAspectFit
+        return iv
+    }()
+
+    private let circleView: UIView = {
+        let view = UIView()
+        view.layer.borderColor = UIColor.white.cgColor
+        view.layer.borderWidth = 1.5
+        return view
+    }()
+
+    private let pulseView: UIView = {
+        let view = UIView()
+        view.alpha = 0
+        return view
+    }()
+
+    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
+        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+        clusteringIdentifier = Self.clusterID
+        setupView()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        collisionMode = .circle
+        frame = CGRect(x: 0, y: 0, width: 36, height: 36)
+        centerOffset = CGPoint(x: 0, y: -18)
+
+        addSubview(pulseView)
+        addSubview(circleView)
+        circleView.addSubview(iconImageView)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        circleView.frame = bounds
+        circleView.layer.cornerRadius = bounds.width / 2
+        iconImageView.frame = bounds.insetBy(dx: 8, dy: 8)
+        pulseView.frame = bounds.insetBy(dx: -4, dy: -4)
+        pulseView.layer.cornerRadius = pulseView.bounds.width / 2
+    }
+
+    override func prepareForDisplay() {
+        super.prepareForDisplay()
+        guard let dealAnnotation = annotation as? DealMapAnnotation else { return }
+        let pin = dealAnnotation.dealPin
+        let color = uiColor(for: pin.category)
+        circleView.backgroundColor = color
+        pulseView.backgroundColor = color
+        iconImageView.image = UIImage(systemName: iconName(for: pin.category))
+    }
+
+    /// Run pulse animation — call after adding to map for new pins.
+    func animatePulse() {
+        pulseView.alpha = 0.5
+        pulseView.transform = .identity
+        UIView.animate(withDuration: 0.8, delay: 0, options: [.curveEaseOut]) {
+            self.pulseView.transform = CGAffineTransform(scaleX: 1.8, y: 1.8)
+            self.pulseView.alpha = 0
+        }
+    }
+
+    override var isSelected: Bool {
+        didSet {
+            UIView.animate(withDuration: 0.25, delay: 0, usingSpringWithDamping: 0.6, initialSpringVelocity: 0.8) {
+                self.transform = self.isSelected ? CGAffineTransform(scaleX: 1.2, y: 1.2) : .identity
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func iconName(for category: String) -> String {
+        switch category.lowercased() {
+        case "drink": return "wineglass.fill"
+        case "food": return "fork.knife"
+        case "both": return "cart.fill"
+        case "flash": return "bolt.fill"
+        default: return "tag.fill"
+        }
+    }
+
+    private func uiColor(for category: String) -> UIColor {
+        switch category.lowercased() {
+        case "drink": return UIColor(red: 0.29, green: 0.56, blue: 0.85, alpha: 1) // #4A90D9
+        case "food": return UIColor(red: 0.49, green: 0.83, blue: 0.13, alpha: 1) // #7ED321
+        case "both": return UIColor(red: 0.61, green: 0.35, blue: 0.71, alpha: 1) // #9B59B6
+        case "flash": return UIColor(red: 0.95, green: 0.61, blue: 0.07, alpha: 1) // #F39C12
+        default: return UIColor(red: 1, green: 0.55, blue: 0, alpha: 1) // #FF8C00
+        }
+    }
+}

--- a/Float/Features/Map/DealMapClusterAnnotation.swift
+++ b/Float/Features/Map/DealMapClusterAnnotation.swift
@@ -1,0 +1,31 @@
+// DealMapClusterAnnotation.swift
+// Float
+
+import MapKit
+
+/// Custom annotation for individual deal pins on the MKMapView.
+/// Supports MapKit's built-in clustering via `clusteringIdentifier`.
+final class DealMapAnnotation: MKPointAnnotation {
+    let dealPin: DealPin
+
+    init(dealPin: DealPin) {
+        self.dealPin = dealPin
+        super.init()
+        self.coordinate = dealPin.coordinate
+        self.title = dealPin.venueName
+        self.subtitle = dealPin.dealTitle
+    }
+}
+
+/// Wrapper around MKClusterAnnotation to expose the member deal pins.
+extension MKClusterAnnotation {
+    /// All DealPin models contained in this cluster.
+    var dealPins: [DealPin] {
+        memberAnnotations.compactMap { ($0 as? DealMapAnnotation)?.dealPin }
+    }
+
+    /// Convenience count of member deal pins.
+    var dealCount: Int {
+        memberAnnotations.count
+    }
+}

--- a/Float/Features/Map/DealMapClusterAnnotationView.swift
+++ b/Float/Features/Map/DealMapClusterAnnotationView.swift
@@ -1,0 +1,76 @@
+// DealMapClusterAnnotationView.swift
+// Float
+
+import MapKit
+import UIKit
+
+/// Annotation view for clustered deal pins — cyan circle with count badge.
+final class DealMapClusterAnnotationView: MKAnnotationView {
+    static let reuseID = "DealCluster"
+
+    private let badgeLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 14, weight: .bold)
+        return label
+    }()
+
+    private let circleView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 0, green: 0.706, blue: 0.847, alpha: 1) // #00b4d8
+        view.layer.borderColor = UIColor.white.cgColor
+        view.layer.borderWidth = 2
+        return view
+    }()
+
+    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
+        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+        setupView()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        collisionMode = .circle
+        addSubview(circleView)
+        circleView.addSubview(badgeLabel)
+        frame = CGRect(x: 0, y: 0, width: 40, height: 40)
+        centerOffset = CGPoint(x: 0, y: -20)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let size = bounds.size
+        circleView.frame = bounds
+        circleView.layer.cornerRadius = size.width / 2
+        badgeLabel.frame = bounds
+    }
+
+    override func prepareForDisplay() {
+        super.prepareForDisplay()
+        guard let cluster = annotation as? MKClusterAnnotation else { return }
+        badgeLabel.text = "\(cluster.memberAnnotations.count)"
+        let size: CGFloat = sizeForCount(cluster.memberAnnotations.count)
+        frame = CGRect(x: 0, y: 0, width: size, height: size)
+        centerOffset = CGPoint(x: 0, y: -size / 2)
+    }
+
+    override var isSelected: Bool {
+        didSet {
+            UIView.animate(withDuration: 0.25, delay: 0, usingSpringWithDamping: 0.6, initialSpringVelocity: 0.8) {
+                self.transform = self.isSelected ? CGAffineTransform(scaleX: 1.3, y: 1.3) : .identity
+            }
+        }
+    }
+
+    private func sizeForCount(_ count: Int) -> CGFloat {
+        switch count {
+        case 0...5: return 40
+        case 6...20: return 50
+        default: return 60
+        }
+    }
+}

--- a/Float/Features/Map/DealMapView.swift
+++ b/Float/Features/Map/DealMapView.swift
@@ -1,0 +1,102 @@
+// DealMapView.swift
+// Float
+
+import SwiftUI
+import MapKit
+
+/// UIViewRepresentable wrapper for MKMapView with clustering support.
+struct DealMapView: UIViewRepresentable {
+    @Binding var region: MKCoordinateRegion
+    let annotations: [DealMapAnnotation]
+    let onSelectAnnotation: (DealMapAnnotation) -> Void
+    let onSelectCluster: (MKClusterAnnotation) -> Void
+
+    func makeUIView(context: Context) -> MKMapView {
+        let mapView = MKMapView()
+        mapView.delegate = context.coordinator
+        mapView.showsUserLocation = true
+        mapView.register(DealMapAnnotationView.self, forAnnotationViewWithReuseIdentifier: DealMapAnnotationView.reuseID)
+        mapView.register(DealMapClusterAnnotationView.self, forAnnotationViewWithReuseIdentifier: DealMapClusterAnnotationView.reuseID)
+        return mapView
+    }
+
+    func updateUIView(_ mapView: MKMapView, context: Context) {
+        // Update region
+        let currentCenter = mapView.region.center
+        let newCenter = region.center
+        let threshold = 0.001
+        if abs(currentCenter.latitude - newCenter.latitude) > threshold ||
+           abs(currentCenter.longitude - newCenter.longitude) > threshold {
+            mapView.setRegion(region, animated: true)
+        }
+
+        // Diff annotations
+        let existing = Set(mapView.annotations.compactMap { ($0 as? DealMapAnnotation)?.dealPin.id })
+        let incoming = Set(annotations.map { $0.dealPin.id })
+
+        let toRemove = mapView.annotations.filter {
+            guard let a = $0 as? DealMapAnnotation else { return false }
+            return !incoming.contains(a.dealPin.id)
+        }
+        let toAdd = annotations.filter { !existing.contains($0.dealPin.id) }
+
+        if !toRemove.isEmpty { mapView.removeAnnotations(toRemove) }
+        if !toAdd.isEmpty {
+            mapView.addAnnotations(toAdd)
+            context.coordinator.newAnnotationIDs = Set(toAdd.map { $0.dealPin.id })
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    final class Coordinator: NSObject, MKMapViewDelegate {
+        let parent: DealMapView
+        var newAnnotationIDs: Set<UUID> = []
+
+        init(_ parent: DealMapView) {
+            self.parent = parent
+        }
+
+        func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+            if annotation is MKUserLocation { return nil }
+
+            if let cluster = annotation as? MKClusterAnnotation {
+                let view = mapView.dequeueReusableAnnotationView(withIdentifier: DealMapClusterAnnotationView.reuseID, for: cluster) as! DealMapClusterAnnotationView
+                return view
+            }
+
+            if let dealAnnotation = annotation as? DealMapAnnotation {
+                let view = mapView.dequeueReusableAnnotationView(withIdentifier: DealMapAnnotationView.reuseID, for: dealAnnotation) as! DealMapAnnotationView
+                return view
+            }
+
+            return nil
+        }
+
+        func mapView(_ mapView: MKMapView, didAdd views: [MKAnnotationView]) {
+            for view in views {
+                guard let pinView = view as? DealMapAnnotationView,
+                      let annotation = pinView.annotation as? DealMapAnnotation,
+                      newAnnotationIDs.contains(annotation.dealPin.id) else { continue }
+                pinView.animatePulse()
+                newAnnotationIDs.remove(annotation.dealPin.id)
+            }
+        }
+
+        func mapView(_ mapView: MKMapView, didSelect annotation: MKAnnotation) {
+            mapView.deselectAnnotation(annotation, animated: false)
+
+            if let cluster = annotation as? MKClusterAnnotation {
+                parent.onSelectCluster(cluster)
+            } else if let dealAnnotation = annotation as? DealMapAnnotation {
+                parent.onSelectAnnotation(dealAnnotation)
+            }
+        }
+
+        func mapView(_ mapView: MKMapView, clusterAnnotationForMemberAnnotations memberAnnotations: [MKAnnotation]) -> MKClusterAnnotation {
+            MKClusterAnnotation(memberAnnotations: memberAnnotations)
+        }
+    }
+}

--- a/Float/Features/Map/MapView.swift
+++ b/Float/Features/Map/MapView.swift
@@ -7,20 +7,24 @@ import MapKit
 struct MapView: View {
     @StateObject private var viewModel = MapViewModel()
     @Environment(\.colorScheme) var colorScheme
-    
+
     var body: some View {
         ZStack(alignment: .bottom) {
-            // Map with deal pins
-            Map(coordinateRegion: $viewModel.region, annotationItems: viewModel.filteredPins) { pin in
-                MapAnnotation(coordinate: pin.coordinate) {
-                    DealPinView(pin: pin, isSelected: viewModel.selectedPin?.id == pin.id)
-                        .onTapGesture { viewModel.selectPin(pin) }
+            // MKMapView with clustering
+            DealMapView(
+                region: $viewModel.region,
+                annotations: viewModel.mapAnnotations,
+                onSelectAnnotation: { annotation in
+                    viewModel.selectPin(annotation.dealPin)
+                },
+                onSelectCluster: { cluster in
+                    viewModel.handleClusterTap(cluster.dealPins)
                 }
-            }
+            )
             .ignoresSafeArea()
-            
-            // Top-right controls
-            VStack(alignment: .trailing, spacing: FloatSpacing.sm) {
+
+            // Top controls
+            VStack {
                 HStack(spacing: FloatSpacing.sm) {
                     // Active Now toggle
                     Button(action: { viewModel.toggleActiveNowFilter() }) {
@@ -35,43 +39,97 @@ struct MapView: View {
                         .foregroundStyle(viewModel.activeNowOnly ? .white : FloatColors.textPrimary)
                         .cornerRadius(FloatSpacing.badgeRadius)
                     }
-                    
+
                     Spacer()
+
+                    // List toggle button
+                    Button(action: { viewModel.toggleListView() }) {
+                        HStack(spacing: FloatSpacing.xs) {
+                            Image(systemName: viewModel.showListView ? "map.fill" : "list.bullet")
+                            Text(viewModel.showListView ? "Map" : "List")
+                                .font(FloatFont.caption(.semibold))
+                        }
+                        .padding(.horizontal, FloatSpacing.sm)
+                        .padding(.vertical, 6)
+                        .background(FloatColors.cardBackground)
+                        .foregroundStyle(FloatColors.textPrimary)
+                        .cornerRadius(FloatSpacing.badgeRadius)
+                        .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
+                    }
                 }
-                .padding(FloatSpacing.md)
-                
+                .padding(.horizontal, FloatSpacing.md)
+                .padding(.top, FloatSpacing.md)
+
                 Spacer()
             }
-            .padding(.top, FloatSpacing.md)
-            .padding(.trailing, FloatSpacing.md)
-            
-            // Bottom sheet with deal details
-            if let selected = viewModel.selectedPin {
+
+            // List view overlay
+            if viewModel.showListView {
+                dealListOverlay
+            }
+
+            // Single deal bottom sheet
+            if let selected = viewModel.selectedPin, !viewModel.showClusterSheet {
                 DealBottomSheet(pin: selected, onDismiss: { viewModel.selectPin(selected) })
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+
+            // Cluster bottom sheet
+            if viewModel.showClusterSheet {
+                ClusteredDealsBottomSheet(
+                    deals: viewModel.clusteredDeals,
+                    userLocation: viewModel.userLocation,
+                    onDismiss: { viewModel.dismissClusterSheet() },
+                    onSelectDeal: { pin in
+                        viewModel.dismissClusterSheet()
+                        viewModel.selectPin(pin)
+                    }
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
         .refreshable { await viewModel.refreshDeals() }
         .task { await viewModel.loadNearbyDeals() }
+    }
+
+    private var dealListOverlay: some View {
+        VStack {
+            Spacer().frame(height: 60)
+            ScrollView {
+                LazyVStack(spacing: FloatSpacing.sm) {
+                    ForEach(viewModel.filteredPins) { pin in
+                        ClusteredDealCard(pin: pin, userLocation: viewModel.userLocation)
+                            .onTapGesture {
+                                viewModel.toggleListView()
+                                viewModel.selectPin(pin)
+                            }
+                    }
+                }
+                .padding(.horizontal, FloatSpacing.md)
+                .padding(.vertical, FloatSpacing.sm)
+            }
+            .background(FloatColors.background.opacity(0.95))
+        }
+        .transition(.opacity)
     }
 }
 
 struct DealPinView: View {
     let pin: DealPin
     let isSelected: Bool
-    
+
     var body: some View {
         VStack(spacing: 2) {
             ZStack {
                 Circle()
                     .fill(pin.categoryColor)
                     .frame(width: isSelected ? 44 : 36, height: isSelected ? 44 : 36)
-                
+
                 Image(systemName: categoryIcon)
                     .foregroundStyle(.white)
                     .font(.system(size: isSelected ? 18 : 14))
             }
-            
+
             Image(systemName: "arrowtriangle.down.fill")
                 .foregroundStyle(pin.categoryColor)
                 .font(.system(size: 8))
@@ -80,7 +138,7 @@ struct DealPinView: View {
         .scaleEffect(isSelected ? 1.1 : 1.0)
         .animation(.spring(response: 0.3, dampingFraction: 0.6), value: isSelected)
     }
-    
+
     private var categoryIcon: String {
         switch pin.category.lowercased() {
         case "drink": return "wineglass.fill"
@@ -96,34 +154,30 @@ struct DealBottomSheet: View {
     let pin: DealPin
     let onDismiss: () -> Void
     @State private var showDetail = false
-    
+
     var body: some View {
         ZStack(alignment: .top) {
-            // Tap-to-dismiss background
             Color.black.opacity(0.4)
                 .ignoresSafeArea()
                 .onTapGesture { onDismiss() }
-            
+
             FloatCard {
                 VStack(alignment: .leading, spacing: FloatSpacing.sm) {
-                    // Handle bar
                     RoundedRectangle(cornerRadius: 2.5)
                         .fill(FloatColors.textSecondary.opacity(0.3))
                         .frame(width: 40, height: 5)
                         .frame(maxWidth: .infinity)
                         .padding(.bottom, FloatSpacing.sm)
-                    
-                    // Deal info
+
                     VStack(alignment: .leading, spacing: FloatSpacing.xs) {
                         Text(pin.venueName)
                             .font(FloatFont.headline())
-                        
+
                         Text(pin.dealTitle)
                             .font(FloatFont.body())
                             .foregroundStyle(FloatColors.textSecondary)
                             .lineLimit(2)
-                        
-                        // Category badge and timer
+
                         HStack(spacing: FloatSpacing.sm) {
                             FloatBadge(pin.category.uppercased(), color: pin.categoryColor)
                             Spacer()
@@ -133,8 +187,7 @@ struct DealBottomSheet: View {
                         }
                     }
                     .padding(.bottom, FloatSpacing.sm)
-                    
-                    // Get Deal CTA
+
                     NavigationLink(destination: DealDetailView(deal: pin.deal)) {
                         FloatButton("Get Deal", icon: "sparkles", style: .primary) {
                             showDetail = true

--- a/Float/Features/Map/MapViewModel.swift
+++ b/Float/Features/Map/MapViewModel.swift
@@ -42,6 +42,14 @@ class MapViewModel: ObservableObject {
     @Published var activeNowOnly: Bool = false
     @Published var userLocation: CLLocationCoordinate2D?
     @Published var isRefreshing = false
+    @Published var clusteredDeals: [DealPin] = []
+    @Published var showClusterSheet = false
+    @Published var showListView = false
+
+    /// MKAnnotation objects for the UIViewRepresentable map.
+    var mapAnnotations: [DealMapAnnotation] {
+        filteredPins.map { DealMapAnnotation(dealPin: $0) }
+    }
     
     private let locationService = LocationService()
     private var locationTask: Task<Void, Never>?
@@ -138,8 +146,29 @@ class MapViewModel: ObservableObject {
     
     func selectPin(_ pin: DealPin) {
         withAnimation(.spring()) {
+            showClusterSheet = false
+            clusteredDeals = []
             selectedPin = selectedPin?.id == pin.id ? nil : pin
         }
+    }
+
+    func handleClusterTap(_ deals: [DealPin]) {
+        withAnimation(.spring()) {
+            selectedPin = nil
+            clusteredDeals = deals
+            showClusterSheet = true
+        }
+    }
+
+    func dismissClusterSheet() {
+        withAnimation(.spring()) {
+            showClusterSheet = false
+            clusteredDeals = []
+        }
+    }
+
+    func toggleListView() {
+        showListView.toggle()
     }
     
     deinit {

--- a/FloatTests/DealMapClusterTests.swift
+++ b/FloatTests/DealMapClusterTests.swift
@@ -1,0 +1,129 @@
+// DealMapClusterTests.swift
+// Float
+
+import XCTest
+import MapKit
+import CoreLocation
+@testable import Float
+
+@MainActor
+final class DealMapClusterTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeDeal(category: String = "drink", distance: Double = 500) -> Deal {
+        Deal(
+            id: UUID(),
+            title: "Test Deal",
+            description: "A test deal",
+            category: category,
+            venueId: UUID(),
+            venueName: "Test Venue",
+            expiresAt: Date().addingTimeInterval(3600),
+            startsAt: Date(),
+            discountType: "percentage",
+            discountValue: 25,
+            terms: nil,
+            distanceFromUser: distance
+        )
+    }
+
+    private func makePin(category: String = "drink") -> DealPin {
+        let deal = makeDeal(category: category)
+        return DealPin(
+            id: deal.id,
+            coordinate: CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060),
+            venueName: deal.venueName ?? "Venue",
+            dealTitle: deal.title,
+            category: category,
+            expiresAt: deal.expiresAt ?? Date(),
+            deal: deal
+        )
+    }
+
+    // MARK: - Test: Cluster annotation init with correct count
+
+    func testClusterAnnotationMemberCount() {
+        let annotations: [MKAnnotation] = (0..<5).map { _ in
+            DealMapAnnotation(dealPin: makePin())
+        }
+        let cluster = MKClusterAnnotation(memberAnnotations: annotations)
+        XCTAssertEqual(cluster.dealCount, 5)
+        XCTAssertEqual(cluster.dealPins.count, 5)
+    }
+
+    // MARK: - Test: Cluster view badge rendering
+
+    func testClusterAnnotationViewBadgeSetup() {
+        let view = DealMapClusterAnnotationView(annotation: nil, reuseIdentifier: DealMapClusterAnnotationView.reuseID)
+        XCTAssertNotNil(view)
+        // View should have subviews for the circle and label
+        XCTAssertFalse(view.subviews.isEmpty)
+    }
+
+    // MARK: - Test: ViewModel correctly assigns clusteringIdentifier via mapAnnotations
+
+    func testViewModelMapAnnotationsHaveClusteringSupport() {
+        let vm = MapViewModel()
+        let pin = makePin(category: "food")
+        vm.dealPins = [pin]
+        vm.filteredPins = [pin]
+
+        let annotations = vm.mapAnnotations
+        XCTAssertEqual(annotations.count, 1)
+        XCTAssertEqual(annotations.first?.dealPin.id, pin.id)
+        XCTAssertEqual(annotations.first?.coordinate.latitude, pin.coordinate.latitude, accuracy: 0.0001)
+    }
+
+    // MARK: - Test: Bottom sheet populates from cluster members
+
+    func testClusteredDealsPopulate() {
+        let vm = MapViewModel()
+        let pins = (0..<3).map { _ in makePin() }
+
+        vm.handleClusterTap(pins)
+
+        XCTAssertTrue(vm.showClusterSheet)
+        XCTAssertEqual(vm.clusteredDeals.count, 3)
+    }
+
+    // MARK: - Test: Single deal pin shows without cluster wrapper
+
+    func testSinglePinAnnotation() {
+        let pin = makePin(category: "food")
+        let annotation = DealMapAnnotation(dealPin: pin)
+
+        XCTAssertEqual(annotation.title, pin.venueName)
+        XCTAssertEqual(annotation.subtitle, pin.dealTitle)
+        XCTAssertEqual(annotation.coordinate.latitude, pin.coordinate.latitude, accuracy: 0.0001)
+    }
+
+    // MARK: - Test: Distance formatting
+
+    func testDistanceFormattingMeters() {
+        let result = ClusteredDealCard.formatDistance(meters: 500)
+        XCTAssertEqual(result, "500m")
+    }
+
+    func testDistanceFormattingMiles() {
+        let result = ClusteredDealCard.formatDistance(meters: 2500)
+        XCTAssertEqual(result, "1.6mi")
+    }
+
+    func testDistanceFormattingZero() {
+        let result = ClusteredDealCard.formatDistance(meters: 0)
+        XCTAssertEqual(result, "0m")
+    }
+
+    // MARK: - Test: Dismiss cluster sheet
+
+    func testDismissClusterSheet() {
+        let vm = MapViewModel()
+        vm.handleClusterTap([makePin()])
+        XCTAssertTrue(vm.showClusterSheet)
+
+        vm.dismissClusterSheet()
+        XCTAssertFalse(vm.showClusterSheet)
+        XCTAssertTrue(vm.clusteredDeals.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
Implements MKClusterAnnotation for dense deal areas on the map.

### Changes
- **DealMapClusterAnnotation.swift** — MKPointAnnotation subclass + MKClusterAnnotation extensions
- **DealMapClusterAnnotationView.swift** — Cyan (#00b4d8) circle with count badge, scales on selection
- **DealMapAnnotationView.swift** — Individual pin with category icon, pulse animation for new pins
- **DealMapView.swift** — UIViewRepresentable wrapping MKMapView with full clustering delegate
- **ClusteredDealsBottomSheet.swift** — Bottom sheet listing clustered deals with name, discount, distance
- **MapView.swift** — Updated with floating List/Map toggle button and cluster sheet
- **MapViewModel.swift** — Cluster tap handling, list view toggle, mapAnnotations property

### Tests (8 tests)
- Cluster annotation member count
- Cluster view badge setup
- ViewModel mapAnnotations generation
- Bottom sheet populates from cluster
- Single pin annotation properties
- Distance formatting (meters)
- Distance formatting (miles)
- Dismiss cluster sheet

Closes #85