### PR TITLE
ci: add workflow_dispatch trigger to all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch:` trigger to workflows that were missing it.

**Files updated:**
- `.github/workflows/ci.yml`
- `.github/workflows/ios-ci.yml`

**Why:** Manual/on-demand workflow triggering was not possible without this trigger.

---
*Created by Forge (JarvisXomware)*