### PR TITLE
fix(ci): use xcodebuild for iOS Simulator builds (fixes UIKit not found)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ concurrency:
 env:
   XCODE_VERSION: "16.2"       # Pin Xcode for reproducible builds
   RUBY_VERSION:  "3.3"
-  SWIFT_STRICT_CONCURRENCY: "complete"
 
 # ── Jobs ─────────────────────────────────────────────────────────────────────
 
@@ -67,24 +66,35 @@ jobs:
       - name: Cache Swift Package Manager
         uses: actions/cache@v4
         with:
-          path: |
-            .build
-            ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
-          restore-keys: ${{ runner.os }}-spm-
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-xcode-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: ${{ runner.os }}-xcode-spm-
 
       # ── Resolve dependencies ───────────────────────────────────────────────
       - name: Resolve SPM dependencies
         run: swift package resolve
 
-      # ── Build (SPM) ────────────────────────────────────────────────────────
-      - name: Build (swift build)
-        run: swift build -c release
+      # ── Build (xcodebuild for iOS Simulator) ──────────────────────────────
+      # Note: `swift build` cannot find UIKit (iOS-only framework).
+      # Use xcodebuild with iOS Simulator destination instead.
+      - name: Build
+        run: |
+          xcodebuild build \
+            -scheme Float \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_ENTITLEMENTS=""
 
       # ── Unit tests ─────────────────────────────────────────────────────────
       - name: Run tests
         run: |
-          swift test --parallel 2>&1 | tee test-output.txt
+          xcodebuild test \
+            -scheme Float \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_ENTITLEMENTS="" 2>&1 | tee test-output.txt
           exit ${PIPESTATUS[0]}
 
       - name: Upload test results
@@ -124,11 +134,9 @@ jobs:
       - name: Cache Swift Package Manager
         uses: actions/cache@v4
         with:
-          path: |
-            .build
-            ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
-          restore-keys: ${{ runner.os }}-spm-
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-xcode-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: ${{ runner.os }}-xcode-spm-
 
       - name: Resolve SPM dependencies
         run: swift package resolve

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -18,21 +18,34 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_15.4.app
 
-      - name: Cache SPM
+      - name: Cache Xcode DerivedData
         uses: actions/cache@v4
         with:
-          path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
-          restore-keys: ${{ runner.os }}-spm-
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-xcode-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: ${{ runner.os }}-xcode-spm-
 
       - name: Resolve dependencies
         run: swift package resolve
 
       - name: Build
-        run: swift build -c release
+        # swift build can't find UIKit (iOS-only framework). Use xcodebuild with iOS Simulator.
+        run: |
+          xcodebuild build \
+            -scheme Float \
+            -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=latest' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_ENTITLEMENTS=""
 
       - name: Test
-        run: swift test --parallel
+        run: |
+          xcodebuild test \
+            -scheme Float \
+            -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=latest' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_ENTITLEMENTS=""
 
   swiftlint:
     name: SwiftLint


### PR DESCRIPTION
## Problem
Both `ci.yml` and `ios-ci.yml` use `swift build -c release` and `swift test` to build the Float iOS app. This fails with:

```
error: no such module 'UIKit'
import UIKit
```

`swift build` builds for the host platform (macOS/Linux). `UIKit` is an iOS-only framework and is not available in a plain `swift build` invocation on macOS.

## Fix
Replace `swift build` / `swift test` with `xcodebuild build` / `xcodebuild test` targeting an iOS Simulator destination:

- `ios-ci.yml` → `platform=iOS Simulator,name=iPhone 15 Pro,OS=latest` (macos-14 / Xcode 15.4)
- `ci.yml` → `platform=iOS Simulator,name=iPhone 16 Pro,OS=latest` (macos-15 / Xcode 16.2)

Also:
- Updated SPM cache path from `.build` to `~/Library/Developer/Xcode/DerivedData` (used by xcodebuild)
- Removed `SWIFT_STRICT_CONCURRENCY` env var (not applicable to xcodebuild)

---
*Created by Forge (JarvisXomware)*